### PR TITLE
Fix Vercel deployment MIME type issue

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "framework": "vite",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,8 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/Countries/', // Make sure this matches your GitHub repository name
+  // Remove base path for Vercel deployment (use root path)
+  // base: '/Countries/', // Only needed for GitHub Pages
   build: {
     outDir: 'dist',
   },


### PR DESCRIPTION
- Remove base path from Vite config for Vercel deployment
- Comment out GitHub Pages specific base path configuration
- Add vercel.json configuration for proper SPA routing
- Configure correct build output directory and framework
- Add rewrites for single-page application routing
- Resolve JavaScript module loading MIME type errors